### PR TITLE
Refactor and clean up

### DIFF
--- a/src/actions/type.py
+++ b/src/actions/type.py
@@ -15,10 +15,7 @@ async def type_text(driver, args, results):
             return
 
         element.clear()
-        element.send_keys(Keys.CONTROL + "a")
-        element.send_keys(Keys.BACK_SPACE)
         element.send_keys(value)
-        element.send_keys(Keys.ENTER)
 
         results[args["step"]] = {
             "result": "success",


### PR DESCRIPTION
Removed unnecessary actions from type_text function
type_text should only type text and not press ENTER.
Enter should be a separate step.